### PR TITLE
Handle unit of measurement (fixes #31)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
 History
 =======
 
+2.1.0 (2020-10-02)
+==================
+
+- h_integrate() now adds a "UNIT" metadata item to the produced raster
+  with the unit of measurement as specified in the input files.
+  Conversely, PointTimeseries reads the "UNIT" metadata item from the
+  rasters and sets it in the returned HTimeseries object.
+
 2.0.0 (2020-01-05)
 ==================
 

--- a/hspatial/test.py
+++ b/hspatial/test.py
@@ -2,7 +2,7 @@ import numpy as np
 from osgeo import gdal, osr
 
 
-def setup_test_raster(filename, value, timestamp=None, srid=4326):
+def setup_test_raster(filename, value, timestamp=None, srid=4326, unit=None):
     """Save value, which is an np array, to a GeoTIFF file."""
     nodata = 1e8
     value[np.isnan(value)] = nodata
@@ -10,6 +10,8 @@ def setup_test_raster(filename, value, timestamp=None, srid=4326):
     try:
         if timestamp:
             f.SetMetadataItem("TIMESTAMP", timestamp.isoformat())
+        if unit:
+            f.SetMetadataItem("UNIT", unit)
         if srid == 4326:
             f.SetGeoTransform((22.0, 0.01, 0, 38.0, 0, -0.01))
         elif srid == 2100:

--- a/tests/test_hspatial.py
+++ b/tests/test_hspatial.py
@@ -206,6 +206,7 @@ class HIntegrateTestCase(TestCase):
         ]
         with open(self.filenames[0], "w") as f:
             f.write(
+                "Unit=microchips\n"
                 "Timezone=EET (UTC+0200)\n"
                 "Location=19.557285 0.0473312 2100\n"  # GGRS87=5000 5000
                 "\n"
@@ -215,6 +216,7 @@ class HIntegrateTestCase(TestCase):
             )
         with open(self.filenames[1], "w") as f:
             f.write(
+                "Unit=microchips\n"
                 "Timezone=EET (UTC+0200)\n"
                 "Location=19.64689 0.04734 2100\n"  # GGRS87=15000 5000
                 "\n"
@@ -224,6 +226,7 @@ class HIntegrateTestCase(TestCase):
             )
         with open(self.filenames[2], "w") as f:
             f.write(
+                "Unit=microchips\n"
                 "Timezone=EET (UTC+0200)\n"
                 "Location=19.88886 0.12857 2100\n"  # GGRS87=42000 14000
                 "\n"
@@ -235,6 +238,7 @@ class HIntegrateTestCase(TestCase):
             # This station is missing the date required,
             # so it should not be taken into account
             f.write(
+                "Unit=microchips\n"
                 "Timezone=EET (UTC+0200)\n"
                 "Location=19.66480 0.15560 2100\n"  # GGRS87=17000 17000
                 "\n"
@@ -276,6 +280,7 @@ class HIntegrateTestCase(TestCase):
             ]
         )
         np.testing.assert_almost_equal(result, expected_result, decimal=4)
+        self.assertEqual(f.GetMetadataItem("UNIT"), "microchips")
         f = None
 
         # Wait long enough to make sure that, if we write to a file, its
@@ -486,7 +491,7 @@ class SetupTestRastersMixin:
     def _setup_raster(self, date, value):
         filename = self._create_filename(date)
         timestamp = self._create_timestamp(date)
-        setup_test_raster(filename, value, timestamp)
+        setup_test_raster(filename, value, timestamp, unit="microkernels")
 
     def _create_filename(self, date):
         result = date.strftime("test-%Y-%m-%d")
@@ -545,6 +550,12 @@ class PointTimeseriesGetTestCase(SetupTestRastersMixin, TestCase):
         prefix = os.path.join(self.tempdir, "test")
         ts = hspatial.PointTimeseries(point, prefix=prefix).get()
         self._check_against_expected(ts)
+
+    def test_unit_of_measurement(self):
+        point = GeoDjangoPoint(22.00501, 37.98501)
+        prefix = os.path.join(self.tempdir, "test")
+        ts = hspatial.PointTimeseries(point, prefix=prefix).get()
+        self.assertEqual(ts.unit, "microkernels")
 
 
 class PointTimeseriesGetDailyTestCase(SetupTestRastersMixin, TestCase):


### PR DESCRIPTION
h_integrate() now adds a "UNIT" metadata item to the produced raster
with the unit of measurement as specified in the input files.
Conversely, PointTimeseries reads the "UNIT" metadata item from the
rasters and sets it in the returned HTimeseries object.